### PR TITLE
Modify output to display PHP DateTime Format Strings

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,3 +3,9 @@
 A simple tool to generate Ruby [strftime](http://www.ruby-doc.org/core/Time.html#method-i-strftime) directives from a given example date.
 
 ![strftimer example](https://s3.eu-west-2.amazonaws.com/edforshaw.co.uk/images/strftimer-is-open-source/example.gif)
+
+## Local Development
+- Clone Repo
+- `bundle install`
+- `ruby strftimer.rb`
+- open localhost at whichever port sinatra provides

--- a/models/token/day.rb
+++ b/models/token/day.rb
@@ -5,9 +5,9 @@ module Token
     def translation
       case value.length
       when 1
-        "%-d"
+        "j"
       when 2
-        "%d"
+        "d"
       end
     end
 

--- a/models/token/day_word.rb
+++ b/models/token/day_word.rb
@@ -6,7 +6,7 @@ module Token
     ABBR_DAY_NAME = /^(#{::Date::ABBR_DAYNAMES.join('|')})$/i
 
     def translation
-      ["%", case_directive, letter_directive].join
+      ["", case_directive, letter_directive].join
     end
 
     private
@@ -18,9 +18,9 @@ module Token
     def letter_directive
       case value
       when DAY_NAME
-        "A"
+        "l"
       when ABBR_DAY_NAME
-        "a"
+        "D"
       end
     end
   end

--- a/models/token/fractional_second.rb
+++ b/models/token/fractional_second.rb
@@ -4,9 +4,9 @@ module Token
 
     def translation
       if value.length == 3
-        "%L"
-      else
-        "%#{value.length}N"
+        "v"
+      else value.length == 6
+        "u"
       end
     end
   end

--- a/models/token/hour.rb
+++ b/models/token/hour.rb
@@ -6,9 +6,9 @@ module Token
     def translation
       case value.length
       when 1
-        meridian_present? ? "%-l" : "%-k"
+        meridian_present? ? "g" : "G"
       when 2
-        meridian_present? ? "%I" : "%H"
+        meridian_present? ? "h" : "H"
       end
     end
 

--- a/models/token/meridian.rb
+++ b/models/token/meridian.rb
@@ -8,9 +8,9 @@ module Token
     def translation
       case value
       when UPPERCASE_REGEXP
-        "%p"
+        "A"
       when LOWERCASE_REGEXP
-        "%P"
+        "a"
       end
     end
   end

--- a/models/token/military_time.rb
+++ b/models/token/military_time.rb
@@ -3,7 +3,7 @@ module Token
     include Token::Base
 
     def translation
-      valid_time? ? "%H%M" : value
+      valid_time? ? "Hi" : value
     end
 
     private

--- a/models/token/minute.rb
+++ b/models/token/minute.rb
@@ -3,7 +3,7 @@ module Token
     include Token::Base
 
     def translation
-      "%M"
+      "i"
     end
   end
 end

--- a/models/token/month.rb
+++ b/models/token/month.rb
@@ -5,9 +5,9 @@ module Token
     def translation
       case value.length
       when 1
-        "%-m"
+        "n"
       when 2
-        "%m"
+        "m"
       end
     end
 

--- a/models/token/month_word.rb
+++ b/models/token/month_word.rb
@@ -6,7 +6,7 @@ module Token
     ABBR_MONTH_NAME = /^(#{::Date::ABBR_MONTHNAMES.compact.join('|')})$/i
 
     def translation
-      ["%", case_directive, letter_directive].join
+      ["", case_directive, letter_directive].join
     end
 
     def date_group
@@ -22,9 +22,9 @@ module Token
     def letter_directive
       case value
       when MONTH_NAME
-        "B"
+        "F"
       when ABBR_MONTH_NAME
-        "b"
+        "M"
       end
     end
   end

--- a/models/token/second.rb
+++ b/models/token/second.rb
@@ -3,7 +3,7 @@ module Token
     include Token::Base
 
     def translation
-      "%S"
+      "s"
     end
   end
 end

--- a/models/token/timezone.rb
+++ b/models/token/timezone.rb
@@ -3,7 +3,7 @@ module Token
     include Token::Base
 
     def translation
-      "%Z"
+      "T"
     end
   end
 end

--- a/models/token/timezone_offset.rb
+++ b/models/token/timezone_offset.rb
@@ -3,7 +3,7 @@ module Token
     include Token::Base
 
     def translation
-      value.include?(":") ? "%:z" : "%z"
+      value.include?(":") ? "P" : "O"
     end
   end
 end

--- a/models/token/year.rb
+++ b/models/token/year.rb
@@ -5,9 +5,9 @@ module Token
     def translation
       case value.length
       when 2
-        "%y"
+        "y"
       when 4
-        "%Y"
+        "Y"
       end
     end
 

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,17 +1,16 @@
 <html>
   <head>
-    <title>strftimer | A Ruby strftime generator</title>
+    <title>dater.dev | A PHP DateTime Format generator</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@700&display=swap" rel="stylesheet">
     <link href="/css/main.css" media="all" rel="stylesheet" type="text/css">
     <script src="/js/main.js"></script>
-    <script src="https://cdn.usefathom.com/script.js" site="XVJZKHLS" defer></script>
   </head>
   <body>
     <header>
-      <h1>strftimer</h1>
+      <h1>PHP DateTime Formatter</h1>
       <h2>
-        A Ruby
-        <a href="http://www.ruby-doc.org/core/Time.html#method-i-strftime">strftime</a>
+        A PHP
+        <a href="https://www.php.net/manual/en/datetime.format.php" target="_blank">DateTime Format</a>
         generator
       </h2>
     </header>
@@ -24,17 +23,11 @@
         <span id="instructions">
           Enter a date in the format you need
         </span>
-
         <span id="strftime">
-          mytime.strftime("<strong id="directives"></strong>")
+          (new DateTime)->format("<strong id="directives"></strong>");
         </span>
 
-        <p id="help">
-          <strong>ordinalize</strong> method available with
-          <a href="https://github.com/rails/rails/tree/master/activesupport">
-            ActiveSupport
-          </a>
-        </p>
+        <p id="help"></p>
       </div>
     </main>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2329654/96549569-8148e600-1264-11eb-9c74-8f74a8e33b66.png)

This PR replaces the output of the tokens to what we'd expect in a DateTime format string.